### PR TITLE
Include site path for multisite using directories

### DIFF
--- a/includes/tab-overview.php
+++ b/includes/tab-overview.php
@@ -67,7 +67,7 @@ class DT_Multisite_Tab_Overview
         if ( isset( $_POST['network_upgrade_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['network_upgrade_nonce'] ) ), 'network_upgrade' ) ) {
             if ( isset( $_POST['url_trigger'] ) ) {
                 global $wpdb;
-                $domains = $wpdb->get_col( "SELECT domain FROM {$wpdb->base_prefix}blogs;" );
+                $domains = $wpdb->get_col( "SELECT CONCAT(domain, path) as domain FROM {$wpdb->base_prefix}blogs;" );
             }
         }
         ?>
@@ -110,7 +110,7 @@ class DT_Multisite_Tab_Overview
                                 jQuery.ajax({
                                     type: 'GET',
                                     datatype: 'json',
-                                    url: 'https://'+v+'/wp-json/'
+                                    url: 'https://'+v+'wp-json/'
                                 });
                                 list.append( v + '<br>')
                                 console.log(v)


### PR DESCRIPTION
Includes the `path` column from the `wp_blog` table in addition to the `domain` column. For subdomain setups, the path will always be `/`, and for subdirectory setups, it will start and end with `/` (e.g. `/site1/`). So ajax URL building is updated appropriately.