### PR TITLE
fix: don't load Puc if wppusher is installed and not managing this plugin

### DIFF
--- a/disciple-tools-multisite.php
+++ b/disciple-tools-multisite.php
@@ -222,7 +222,6 @@ register_deactivation_hook( __FILE__, [ 'DT_Multisite', 'deactivation' ] );
 require( 'includes/admin/plugin-update-checker/plugin-update-checker.php' );
 
 if ( !function_exists( 'is_wppusher_managing_plugin' ) ) {
-
     /**
      * Utility function to check if wppusher is managing a plugin
      *
@@ -240,9 +239,13 @@ if ( !function_exists( 'is_wppusher_managing_plugin' ) ) {
         if ( class_exists( '\Pusher\Storage\PackageModel' ) ) {
             $table_name = pusherTableName();
 
-            $model = new \Pusher\Storage\PackageModel(array('package' => $file));
+            $model = new \Pusher\Storage\PackageModel( array( 'package' => $file ) );
 
-            $row = $wpdb->get_row("SELECT * FROM $table_name WHERE type = 1 AND package = '{$model->package}'");
+            $row = $wpdb->get_row( $wpdb->prepare(
+                "SELECT * FROM %s
+                WHERE type = 1
+                AND package = '{%s}'
+            " ), $table_name, $model->package );
         }
 
         if ( !$row ) {
@@ -251,12 +254,11 @@ if ( !function_exists( 'is_wppusher_managing_plugin' ) ) {
 
         return true;
     }
-
 }
 
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 add_action( 'plugins_loaded', function (){
-    include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
     $is_wppusher_active = is_plugin_active( 'wppusher/wppusher.php' );
 

--- a/disciple-tools-multisite.php
+++ b/disciple-tools-multisite.php
@@ -242,10 +242,10 @@ if ( !function_exists( 'is_wppusher_managing_plugin' ) ) {
             $model = new \Pusher\Storage\PackageModel( array( 'package' => $file ) );
 
             $row = $wpdb->get_row( $wpdb->prepare(
-                "SELECT * FROM %s
+                "SELECT * FROM %1s
                 WHERE type = 1
-                AND package = '{%s}'
-            " ), $table_name, $model->package );
+                AND package = %s
+            ", $table_name, "{$model->package}" ) );
         }
 
         if ( !$row ) {


### PR DESCRIPTION
This prevents the filter on upgrader_source_selection in Puc from conflicting with the same filter in wppusher and causing some wppusher managed plugins to be prevented from updating with errors like 'subdirectory is missing' etc.

## The issue

When using wppusher in development, some plugins would fail to update with the error message

`WP Pusher couldn't find subdirectory in repository.`

This error, is caused by a conflict on the `upgrader_source_selection` filter that is used by wppusher in it's file `PluginUpgrader.php` line 73, and also by Puc in disciple-tools-multisite/includes/admin/plugin-update-checker/Puc/v5p1/UpdateChecker.php

The Puc filter would fix the directory name, but unintentionally cause the source and targets to be equal and cause a filesystem move function to fail.

This fix, attempts a solution at preventing this conflict, by disablling the Puc in the eventuality of wppusher being active, and warns the admin of the conflict if wppusher is not being used to manage this plugin