### PR TITLE
Add multisite user permissions admin tab

### DIFF
--- a/disciple-tools-multisite.php
+++ b/disciple-tools-multisite.php
@@ -112,6 +112,7 @@ class DT_Multisite {
             require_once( 'includes/tab-cloudflare.php' );
             require_once( 'includes/tab-ai.php' );
             require_once( 'includes/tab-storage.php' );
+            require_once( 'includes/tab-user-permissions.php' );
         }
 
         if ( is_admin() || is_network_admin() ) {

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -92,6 +92,9 @@ function dt_multisite_network_admin_content(){
             <a href="<?php echo esc_attr( $link ) . 'storage' ?>" class="nav-tab <?php echo ( $tab == 'storage' ) ? esc_attr( 'nav-tab-active' ) : ''; ?>">
                 <?php echo esc_attr( 'Storage' ) ?>
             </a>
+            <a href="<?php echo esc_attr( $link ) . 'user_permissions' ?>" class="nav-tab <?php echo ( $tab == 'user_permissions' ) ? esc_attr( 'nav-tab-active' ) : ''; ?>">
+                <?php echo esc_attr( 'User Permissions' ) ?>
+            </a>
         </h2>
 
         <?php
@@ -138,6 +141,10 @@ function dt_multisite_network_admin_content(){
                 break;
             case 'storage':
                 $object = new DT_Multisite_Tab_Storage();
+                $object->content();
+                break;
+            case 'user_permissions':
+                $object = new DT_Multisite_Tab_User_Permissions();
                 $object->content();
                 break;
 

--- a/includes/tab-user-permissions.php
+++ b/includes/tab-user-permissions.php
@@ -1,0 +1,105 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+/**
+ * DT_Multisite_Tab_User_Permissions
+ *
+ * Network admin tab for managing user permission settings across the multisite network
+ */
+class DT_Multisite_Tab_User_Permissions {
+
+    public function content() {
+        // Handle form submission
+        if ( isset( $_POST['dt_multisite_user_permissions_nonce'] )
+             && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['dt_multisite_user_permissions_nonce'] ) ), 'dt_multisite_user_permissions' ) ) {
+            $this->process_form();
+        }
+
+        ?>
+        <div class="wrap">
+            <div id="poststuff">
+                <div id="post-body" class="metabox-holder columns-1">
+                    <div id="post-body-content">
+
+                        <!-- User Permissions Settings -->
+                        <div class="postbox">
+                            <h3 class="hndle">
+                                <?php esc_html_e( 'Subsite Administrator User Permissions', 'disciple-tools-multisite' ); ?>
+                            </h3>
+                            <div class="inside">
+                                <?php $this->user_permissions_settings(); ?>
+                            </div>
+                        </div>
+                        <!-- End User Permissions Settings -->
+
+                    </div>
+                </div>
+            </div>
+        </div>
+        <?php
+    }
+
+    private function process_form() {
+        if ( ! is_super_admin() ) {
+            wp_die( 'You do not have sufficient permissions to access this page.' );
+        }
+
+        $allow_subsite_admins_edit_users = isset( $_POST['dt_allow_subsite_admins_edit_users'] ) ? 1 : 0;
+        update_site_option( 'dt_allow_subsite_admins_edit_users', $allow_subsite_admins_edit_users );
+
+        ?>
+        <div class="notice notice-success is-dismissible">
+            <p><?php esc_html_e( 'Settings saved successfully.', 'disciple-tools-multisite' ); ?></p>
+        </div>
+        <?php
+    }
+
+    private function user_permissions_settings() {
+        $allow_subsite_admins_edit_users = get_site_option( 'dt_allow_subsite_admins_edit_users', false );
+
+        ?>
+        <form method="post" action="">
+            <?php wp_nonce_field( 'dt_multisite_user_permissions', 'dt_multisite_user_permissions_nonce' ); ?>
+
+            <table class="form-table">
+                <tbody>
+                    <tr>
+                        <th scope="row">
+                            <label for="dt_allow_subsite_admins_edit_users">
+                                <?php esc_html_e( 'Allow Subsite Administrators to Edit Users', 'disciple-tools-multisite' ); ?>
+                            </label>
+                        </th>
+                        <td>
+                            <input type="checkbox"
+                                   id="dt_allow_subsite_admins_edit_users"
+                                   name="dt_allow_subsite_admins_edit_users"
+                                   value="1"
+                                   <?php checked( $allow_subsite_admins_edit_users, 1 ); ?> />
+
+                            <p class="description">
+                                <?php esc_html_e( 'When enabled, administrators on subsites can edit user details (including passwords and email addresses) for users within their own subsite.', 'disciple-tools-multisite' ); ?>
+                            </p>
+
+                            <p class="description">
+                                <strong><?php esc_html_e( 'Security Restrictions:', 'disciple-tools-multisite' ); ?></strong><br>
+                                • <?php esc_html_e( 'Super admin accounts cannot be edited by subsite administrators', 'disciple-tools-multisite' ); ?><br>
+                                • <?php esc_html_e( 'Users from other subsites cannot be edited', 'disciple-tools-multisite' ); ?><br>
+                                • <?php esc_html_e( 'Only users who are members of the current subsite can be edited', 'disciple-tools-multisite' ); ?>
+                            </p>
+
+                            <p class="description">
+                                <strong style="color: #d63638;"><?php esc_html_e( 'Security Note:', 'disciple-tools-multisite' ); ?></strong>
+                                <?php esc_html_e( 'Enable this only if you trust your subsite administrators, as they will be able to reset passwords and change email addresses for users on their sites.', 'disciple-tools-multisite' ); ?>
+                            </p>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <?php submit_button( __( 'Save Settings', 'disciple-tools-multisite' ) ); ?>
+        </form>
+        <?php
+    }
+}

--- a/includes/tab-user-permissions.php
+++ b/includes/tab-user-permissions.php
@@ -11,12 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class DT_Multisite_Tab_User_Permissions {
 
     public function content() {
-        // Handle form submission
-        if ( isset( $_POST['dt_multisite_user_permissions_nonce'] )
-             && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['dt_multisite_user_permissions_nonce'] ) ), 'dt_multisite_user_permissions' ) ) {
-            $this->process_form();
-        }
-
+        $this->process_post();
         ?>
         <div class="wrap">
             <div id="poststuff">
@@ -41,19 +36,24 @@ class DT_Multisite_Tab_User_Permissions {
         <?php
     }
 
-    private function process_form() {
-        if ( ! is_super_admin() ) {
-            wp_die( 'You do not have sufficient permissions to access this page.' );
+    public function process_post() {
+        // Handle form submission
+        if ( isset( $_POST['dt_multisite_user_permissions_nonce'] )
+             && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['dt_multisite_user_permissions_nonce'] ) ), 'dt_multisite_user_permissions' ) ) {
+
+            if ( ! is_super_admin() ) {
+                wp_die( 'You do not have sufficient permissions to access this page.' );
+            }
+
+            $allow_subsite_admins_edit_users = isset( $_POST['dt_allow_subsite_admins_edit_users'] ) ? 1 : 0;
+            update_site_option( 'dt_allow_subsite_admins_edit_users', $allow_subsite_admins_edit_users );
+
+            ?>
+            <div class="notice notice-success is-dismissible">
+                <p><?php esc_html_e( 'Settings saved successfully.', 'disciple-tools-multisite' ); ?></p>
+            </div>
+            <?php
         }
-
-        $allow_subsite_admins_edit_users = isset( $_POST['dt_allow_subsite_admins_edit_users'] ) ? 1 : 0;
-        update_site_option( 'dt_allow_subsite_admins_edit_users', $allow_subsite_admins_edit_users );
-
-        ?>
-        <div class="notice notice-success is-dismissible">
-            <p><?php esc_html_e( 'Settings saved successfully.', 'disciple-tools-multisite' ); ?></p>
-        </div>
-        <?php
     }
 
     private function user_permissions_settings() {


### PR DESCRIPTION
Adds a network-wide setting to allow subsite administrators to edit users within their own subsites. This complements the capability filters implemented in disciple-tools-theme PR #2789.

Features:
- New User Permissions tab in Network Admin > Disciple.Tools menu
- Checkbox to enable/disable subsite admin user editing capability
- Security documentation explaining restrictions (no super admin editing, no cross-subsite editing)
- Uses site option 'dt_allow_subsite_admins_edit_users' (disabled by default)

Changes:
- Created includes/tab-user-permissions.php with settings UI
- Added tab registration in disciple-tools-multisite.php
- Added tab navigation and routing in includes/admin-page.php

Security: Feature is disabled by default and requires explicit super admin action to enable.